### PR TITLE
Initial commit of streamzi event-registry project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
-# event-registry
-SImple registry that uses Zookeeper to keep track of event types, topics etc.
+# The event-registry
+Simple registry that uses Zookeeper to keep track of event types, topics etc. It is implemented as a simple wrapper around the apache curator zookeeper library that adds a simple model and zookeeper manipulation operations.
+
+Each update to the registry can generate events that different listeners can receive. So, for exmaple, when a new EventType is registered a router component could receive this update and create any necessary topics. Likewise when a component expresses an interest in a type of event (via an ```@Consumes``` annotation, connections to the correct topic can be made.
+
+
+# Connecting to the Registry
+
+To use the registry, make a connection to a running zookeeper server and start the connection:
+
+```
+RegistryConnetion connection = new RegistryConnection("localhost:2181");
+connection.setBaseKey("/streamzi")
+connection.connect();
+```
+
+The connection is created with a base key argument which attaches to the specified point in the Zookeeper data. All operations are then relative to that base key.
+
+# Updating the Registry
+
+When a registry connection has been made, updates are made via ```RegistryOperations```. These can either run asynchronously or synchronously. For example, to register a new EventType synchronously:
+
+```
+connection.executeSync(new CreateEventType(new EventType("MeterReading"));
+
+```
+or
+
+```
+connection.execute(new CreateEventType(new EventType("MeterReading")).thenRun(
+	new Runnable(){
+		public void run(){
+			System.out.println("Event type added");
+		}
+	}
+
+);
+```
+for an async operation.
+
+# Listening to changes
+
+Registry listeners can be created to listen for changes to specific object types. For example to listen for changes to EventTypes:
+
+```
+	RegistryKeyListener<EventType> listner = connection.addKeyListener(new RegistryKeyListener<>(){
+		@Override
+		public void objectAdded(EventType value){
+		}
+		
+		@Override
+		public void objectRemoved(EventType value){
+		}
+	
+		@Override
+		public void objectChanged(EventType value({
+		}
+	
+	});
+
+```
+
+Listeners are attached to a specific ```key``` in the Zookeeper tree and listen for child events on that key. They also keep a cache of the current state, so can be iterrogated directly:
+
+```
+	List<EventType> eventTypes = listener.getValues();
+```
+will return the locally cached list of event types.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <name>event-registry</name>
+    <version>0.0.1-SNAPSHOT</version>
+    <groupId>io.streamzi</groupId>
+    <artifactId>core</artifactId>
+    <packaging>jar</packaging>
+    
+    <properties>
+        <runSuite>io.streamzi.registry.tests.CoreTests</runSuite>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>        
+    </properties>
+   
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <test>CoreTestSuite</test>
+                </configuration>               
+            </plugin>
+        </plugins>
+    </build>
+   
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-recipes</artifactId>    
+            <version>2.12.0</version>        
+        </dependency>     
+        
+        <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>2.12.0</version>
+            <scope>test</scope>
+        </dependency>
+           
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+            
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.2.3</version>
+        </dependency>
+            
+                            
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/io/streamzi/registry/RegistryConnection.java
+++ b/src/main/java/io/streamzi/registry/RegistryConnection.java
@@ -1,0 +1,235 @@
+package io.streamzi.registry;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.logging.Logger;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+
+/**
+ * This class maintains a connection to a Zookeper server
+ *
+ * @author hhiden
+ */ 
+public class RegistryConnection implements Closeable {
+    private static final Logger logger = Logger.getLogger(RegistryConnection.class.getName());
+    
+    private String baseKey = "/strombrau";
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+    private CopyOnWriteArrayList<RegistryKeyListener> listeners = new CopyOnWriteArrayList<>();
+    
+
+    @Override
+    public void close() throws IOException {
+        // No more operations
+        executor.shutdownNow();
+        
+        // Shutdown the listners
+        for(RegistryKeyListener l : listeners){
+            l.close();
+        }
+
+        // CLose the client
+        client.close();
+    }
+
+    /**
+     * Perform an operation synchronously
+     */
+    public void executeSync(RegistryOperation operation) throws RegistryException {
+        assertConnected();
+        operation.setConnection(this);
+        operation.performOperation();
+    }
+    
+    /**
+     * Perform an operation on the registry
+     * @param operation to be performed
+     * @return a Future object that can be used late r
+     * @throws RegistryException if the registry connection has been closed
+     */
+    public CompletableFuture execute(RegistryOperation operation) {
+        if(!executor.isShutdown()){
+            CompletableFuture<RegistryOperation> future = new CompletableFuture<>();
+            operation.setConnection(this);
+            executor.submit(()->{
+                try {
+                    operation.performOperation();
+                    future.complete(operation);
+                } catch (Exception e){
+                    future.completeExceptionally(e);
+                }
+            });
+            return future;
+        } else {
+            CompletableFuture<RegistryOperation> future = new CompletableFuture<>();
+            executor.submit(()->{
+                future.completeExceptionally(new RegistryException("Registry not connected"));
+            });
+            return future;
+        }
+    }
+    
+    /**
+     * Add a listener
+     */
+    public RegistryKeyListener addKeyListener(String key, RegistryKeyListener listener) throws RegistryException {
+        assertConnected();
+        try {
+            // Add the key if needed
+            if(!keyExists(buildKey(key))){
+                client.create().creatingParentContainersIfNeeded().forPath(buildKey(key));
+            }
+            
+            synchronized(listeners){
+                listener.setup(key, this);
+                listeners.add(listener);
+            }
+            return listener;
+        } catch (Exception e){
+            throw new RegistryException("Error adding RegistryKeyListener: " + e.getMessage(), e);
+        }
+    }
+    
+    /** 
+     * Remove a listener
+     */
+    protected void removeKeyListener(RegistryKeyListener listener){
+        synchronized(listeners){
+            listeners.remove(listener);
+        }
+    }
+    
+    
+    /**
+     * URL pointing to the zookeeper instance that maintains all of the state data
+     */
+    private String zookeeperUrl;
+
+    private CuratorFramework client;
+    private volatile boolean connected = false;
+
+    public String getBaseKey() {
+        return baseKey;
+    }
+
+    public void setBaseKey(String baseKey) {
+        this.baseKey = baseKey;
+    }
+
+    public RegistryConnection(String zookeeperUrl) {
+        this.zookeeperUrl = zookeeperUrl;
+    }
+
+    public void connect() {
+        try {
+            client = CuratorFrameworkFactory.newClient(zookeeperUrl, new ExponentialBackoffRetry(1000, 3));
+            client.start();
+            client.blockUntilConnected();
+            
+            client.getConnectionStateListenable().addListener(new ConnectionStateListener() {
+                @Override
+                public void stateChanged(CuratorFramework client, ConnectionState newState) {
+                    logger.info("Connection state change: " + newState.toString());
+                }
+            });
+            
+            connected = true;
+
+        } catch (Exception e) {
+            connected = false;
+        }
+    }
+
+    public CuratorFramework getClient() {
+        return client;
+    }
+
+    private void assertConnected() throws RegistryException {
+        if (!connected) {
+            throw new RegistryException("Registry not connected to Zookeper");
+        }
+    }
+
+    public void addChildForKey(String key, String child) throws RegistryException {
+        assertConnected();
+        try {
+            if(!keyExists(buildKey(key) + "/" + child)){
+                client.create().creatingParentContainersIfNeeded().forPath(buildKey(key) + "/" + child);
+            }
+        } catch (Exception e){
+            throw new RegistryException("Error adding child: " + child, e);
+        }
+    }
+    
+    public void setStringForKey(String key, String value) throws RegistryException {
+        assertConnected();
+        try {
+            if(!keyExists(buildKey(key))){
+                client.create().creatingParentContainersIfNeeded().forPath(buildKey(key));
+            }
+            client.setData().forPath(buildKey(key), value.getBytes());
+        } catch (Exception e){
+            throw new RegistryException("Error setting data for key: " + key, e);
+        }
+    }
+    
+    public List<String> getChildStringsForKey(String key) throws RegistryException {
+        assertConnected();
+        try {
+            List<String> children = client.getChildren().forPath(buildKey(key));
+            for(String c : children){
+                logger.info(c);
+            }
+            return children;
+        } catch (Exception e){
+            throw new RegistryException("Error listing children for key: " + key, e);
+        }
+    }
+    
+    public String getStringForKey(String key) throws RegistryException {
+        assertConnected();
+        try {
+            byte[] data = client.getData().forPath(buildKey(key));
+            return new String(data);
+        } catch (Exception e) {
+            throw new RegistryException("Error getting data for: " + key, e);
+        }
+    }
+    
+    public void removeKey(String key) throws RegistryException {
+        assertConnected();
+        try {
+            if(keyExists(buildKey(key))){
+                client.delete().forPath(buildKey(key));
+            }
+        } catch (Exception e){
+            throw new RegistryException("Error removing key: " + key, e);
+        }
+    }
+    
+    private boolean keyExists(String key) throws RegistryException {
+        assertConnected();
+        try {
+            return(client.checkExists().forPath(key)!=null);
+        } catch (Exception e){
+            throw new RegistryException("Error checking if key exists: " + key, e);
+        }
+    }
+    
+    protected String buildKey(String key){
+        return baseKey + "/" + key;
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+}

--- a/src/main/java/io/streamzi/registry/RegistryConnection.java
+++ b/src/main/java/io/streamzi/registry/RegistryConnection.java
@@ -26,7 +26,7 @@ public class RegistryConnection implements Closeable {
     private static final Logger logger = Logger.getLogger(RegistryConnection.class.getName());
     
     private String baseKey = "/strombrau";
-    private ExecutorService executor = Executors.newSingleThreadExecutor();
+    private ExecutorService executor;
     private CopyOnWriteArrayList<RegistryKeyListener> listeners = new CopyOnWriteArrayList<>();
 
     public RegistryConnection() {

--- a/src/main/java/io/streamzi/registry/RegistryException.java
+++ b/src/main/java/io/streamzi/registry/RegistryException.java
@@ -1,0 +1,32 @@
+package io.streamzi.registry;
+
+/**
+ *
+ * @author hhiden
+ */
+public class RegistryException extends Exception {
+
+    /**
+     * Creates a new instance of <code>RegistryException</code> without detail message.
+     */
+    public RegistryException() {
+    }
+
+    /**
+     * Constructs an instance of <code>RegistryException</code> with the specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public RegistryException(String msg) {
+        super(msg);
+    }
+    
+    /**
+     * Counstructs an exception with both a detail message and a cause
+     * @param msg detail message
+     * @param cause underlying cause
+     */
+    public RegistryException(String msg, Throwable cause){
+        super(msg, cause);
+    }
+}

--- a/src/main/java/io/streamzi/registry/RegistryKeyListener.java
+++ b/src/main/java/io/streamzi/registry/RegistryKeyListener.java
@@ -1,0 +1,132 @@
+package io.streamzi.registry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.PathChildrenCache;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+
+/**
+ * This class defines a listener that receives events from a single key in the registry
+ *
+ * @author hhiden
+ */
+public abstract class RegistryKeyListener<T> {
+    private static final Logger logger = Logger.getLogger(RegistryKeyListener.class.getName());
+    
+    private ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private PathChildrenCache cache;
+    private RegistryConnection connection;
+    private String key;
+
+    public RegistryKeyListener() {
+    }
+
+    protected void setup(String key, RegistryConnection connection) throws RegistryException {
+        this.connection = connection;
+        this.key = key;
+        try {
+            cache = new PathChildrenCache(connection.getClient(), connection.buildKey(key), true);
+            cache.start();
+            cache.rebuild();
+            cache.getListenable().addListener(new PathChildrenCacheListener() {
+                @Override
+                public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+                    switch(event.getType()){
+                        case CHILD_ADDED:
+                            try {
+                                byte[] data = event.getData().getData();
+                                T keyValue = recreatObject(data);
+                                objectAdded(keyValue);
+                            } catch (Exception e){
+                                logger.log(Level.SEVERE, "Error processing CHILD_ADDED event: " + e.getMessage(), e);
+                            }
+                            
+                            break;
+                            
+                        case CHILD_REMOVED:
+                            try {
+                                byte[] data = event.getData().getData();
+                                T keyValue = recreatObject(data);
+                                objectRemoved(keyValue);
+                            } catch (Exception e){
+                                logger.log(Level.SEVERE, "Error processing CHILD_REMOVED event: " + e.getMessage(), e);
+                            }                            
+                            break;
+                            
+                        case CHILD_UPDATED:
+                            try {
+                                byte[] data = event.getData().getData();
+                                T keyValue = recreatObject(data);
+                                objectChanged(keyValue);
+                            } catch (Exception e){
+                                logger.log(Level.SEVERE, "Error processing CHILD_UPDATED event: " + e.getMessage(), e);
+                            }                            
+                            break;
+                            
+                        default:
+                            logger.info(event.getType().toString());
+                    }
+                }
+            });
+        
+        } catch (Exception e){
+        }    
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void close(){
+        if(connection!=null){
+            if(cache!=null){
+                try {
+                    cache.close();
+                } catch(Exception e){
+                    logger.log(Level.SEVERE, "Error closing cache: " + e.getMessage(), e);
+                }
+            }
+            connection.removeKeyListener(this);
+            connection = null;
+            
+        }
+    }
+    
+    public List<T> getValues() throws RegistryException {
+        try {
+            ArrayList<T> results = new ArrayList<>();
+            for(ChildData child : cache.getCurrentData()){
+                results.add(recreatObject(child.getData()));
+            }
+            return results;
+        } catch (Exception e){
+            throw new RegistryException("Cannot get cached values; " + e.getMessage(), e);
+        }
+    }
+    
+    private T recreatObject(byte[] data) throws RegistryException {
+        try {
+            Type superclassType = getClass().getGenericSuperclass();
+            Type t = ((ParameterizedType) superclassType).getActualTypeArguments()[0];
+            Class cls = Class.forName(t.getTypeName());
+            return (T) mapper.readValue(data, cls);
+        } catch (Exception e) {
+            throw new RegistryException("Error creating object: " + e.getMessage(), e);
+        }
+    }
+
+    public abstract void objectAdded(T value);
+
+    public abstract void objectRemoved(T value);
+
+    public abstract void objectChanged(T value);
+}

--- a/src/main/java/io/streamzi/registry/RegistryKeyListenerAdapter.java
+++ b/src/main/java/io/streamzi/registry/RegistryKeyListenerAdapter.java
@@ -1,0 +1,24 @@
+package io.streamzi.registry;
+
+/**
+ * Simple class to dump registry key events
+ * @author hhiden
+ */
+public class RegistryKeyListenerAdapter<T> extends RegistryKeyListener<T>{
+
+    @Override
+    public void objectAdded(T value) {
+
+    }
+
+    @Override
+    public void objectRemoved(T value) {
+
+    }
+
+    @Override
+    public void objectChanged(T value) {
+
+    }
+    
+}

--- a/src/main/java/io/streamzi/registry/RegistryOperation.java
+++ b/src/main/java/io/streamzi/registry/RegistryOperation.java
@@ -1,0 +1,30 @@
+package io.streamzi.registry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.snakeyaml.Yaml;
+import java.util.concurrent.FutureTask;
+
+/**
+ * Represents an operation that can be performed on the registry
+ * @author hhiden
+ */
+public abstract class RegistryOperation {
+    protected ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    
+    protected RegistryConnection connection;
+
+    public RegistryOperation() {
+        super();
+    }
+
+    public void setConnection(RegistryConnection connection) {
+        this.connection = connection;
+    }
+
+    public RegistryConnection getConnection() {
+        return connection;
+    }
+    
+    public abstract void performOperation() throws RegistryException;
+}

--- a/src/main/java/io/streamzi/registry/items/EventType.java
+++ b/src/main/java/io/streamzi/registry/items/EventType.java
@@ -1,0 +1,24 @@
+package io.streamzi.registry.items;
+
+/**
+ * Represents a type of event stored in the registry
+ * @author hhiden
+ */
+public class EventType {
+    public String name;
+    public String topicName = "";
+
+    public EventType() {
+    }
+
+    public EventType(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name + "->" + topicName;
+    }
+    
+    
+}

--- a/src/main/java/io/streamzi/registry/operations/CreateEventType.java
+++ b/src/main/java/io/streamzi/registry/operations/CreateEventType.java
@@ -1,0 +1,29 @@
+package io.streamzi.registry.operations;
+
+import io.streamzi.registry.RegistryException;
+import io.streamzi.registry.RegistryOperation;
+import io.streamzi.registry.items.EventType;
+
+/**
+ * Create a new type of event
+ * @author hhiden
+ */
+public class CreateEventType extends RegistryOperation {
+    private EventType evt;
+    
+    public CreateEventType(EventType evt) {
+        this.evt = evt;
+    }
+
+    @Override
+    public void performOperation() throws RegistryException {
+        try {
+            String data = mapper.writeValueAsString(evt);
+            String key = "events/" + evt.name;
+            connection.addChildForKey("events", evt.name);
+            connection.setStringForKey(key, data);
+        } catch (Exception ex){
+            throw new RegistryException("Error performing operation" , ex);
+        }
+    }
+}

--- a/src/main/java/io/streamzi/registry/operations/GetEventType.java
+++ b/src/main/java/io/streamzi/registry/operations/GetEventType.java
@@ -1,0 +1,33 @@
+package io.streamzi.registry.operations;
+
+import io.streamzi.registry.RegistryException;
+import io.streamzi.registry.RegistryOperation;
+import io.streamzi.registry.items.EventType;
+
+/**
+ * Get an event type with a specified name
+ * @author hhiden
+ */
+public class GetEventType extends RegistryOperation {
+    private String name;
+    private EventType eventType;
+
+    public GetEventType(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public void performOperation() throws RegistryException {
+        try {
+            String key = "events/" + name;
+            String data = connection.getStringForKey(key);
+            eventType = mapper.readValue(data, EventType.class);
+        } catch (Exception ex){
+            throw new RegistryException("Error performing operation" , ex);
+        }
+    }
+
+    public EventType getEventType() {
+        return eventType;
+    }
+}

--- a/src/main/java/io/streamzi/registry/operations/ListEventTypes.java
+++ b/src/main/java/io/streamzi/registry/operations/ListEventTypes.java
@@ -1,0 +1,31 @@
+package io.streamzi.registry.operations;
+
+import io.streamzi.registry.RegistryException;
+import io.streamzi.registry.RegistryOperation;
+import io.streamzi.registry.items.EventType;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Lists all of the event types
+ * @author hhiden
+ */
+public class ListEventTypes extends RegistryOperation {
+    private final List<EventType> results = new ArrayList<>();
+    
+    @Override
+    public void performOperation() throws RegistryException {
+        try {
+            List<String> children = connection.getChildStringsForKey("events");
+            for(String child : children){
+                results.add(mapper.readValue("evets/" + child, EventType.class));
+            }
+        } catch (Exception ex){
+            throw new RegistryException("Error performing operation" , ex);
+        }
+    }
+
+    public List<EventType> getResults() {
+        return results;
+    }
+}

--- a/src/main/java/io/streamzi/registry/operations/RemoveEventType.java
+++ b/src/main/java/io/streamzi/registry/operations/RemoveEventType.java
@@ -1,0 +1,30 @@
+package io.streamzi.registry.operations;
+
+import io.streamzi.registry.RegistryException;
+import io.streamzi.registry.RegistryOperation;
+import io.streamzi.registry.items.EventType;
+
+/**
+ * Removes an event type from the registry
+ * @author hhiden
+ */
+public class RemoveEventType extends RegistryOperation {
+    String eventTypeName;
+
+    public RemoveEventType(String name) {
+        this.eventTypeName = name;
+    }
+    
+    public RemoveEventType(EventType eventType){
+        this.eventTypeName = eventType.name;
+    }
+
+    @Override
+    public void performOperation() throws RegistryException {
+        try {
+            connection.removeKey("events/" + eventTypeName);
+        } catch (Exception ex){
+            throw new RegistryException("Error performing operation" , ex);
+        }        
+    }    
+}

--- a/src/test/java/io/streamzi/registry/tests/CoreTestSuite.java
+++ b/src/test/java/io/streamzi/registry/tests/CoreTestSuite.java
@@ -1,0 +1,49 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package io.streamzi.registry.tests;
+
+import java.util.logging.Logger;
+import org.apache.curator.test.TestingServer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Run all of the core tests
+ * @author hhiden
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    RegistryTest.class,
+    EventTest.class
+})
+public class CoreTestSuite {
+    private static final Logger logger = Logger.getLogger(CoreTestSuite.class.getName());
+    private static TestingServer testServer;
+    
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        logger.info("Setup Class");
+        testServer = new TestingServer(2181, true);
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        logger.info("Teardown class");
+        testServer.close(); // Deletes storage
+    }
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {   
+    }
+}

--- a/src/test/java/io/streamzi/registry/tests/EventTest.java
+++ b/src/test/java/io/streamzi/registry/tests/EventTest.java
@@ -1,0 +1,141 @@
+package io.streamzi.registry.tests;
+
+import io.streamzi.registry.RegistryConnection;
+import io.streamzi.registry.RegistryException;
+import io.streamzi.registry.RegistryKeyListener;
+import io.streamzi.registry.items.EventType;
+import io.streamzi.registry.operations.CreateEventType;
+import io.streamzi.registry.operations.ListEventTypes;
+import io.streamzi.registry.operations.RemoveEventType;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Tests basic event listening
+ *
+ * @author hhiden
+ */
+public class EventTest {
+
+    private static final Logger logger = Logger.getLogger(EventTest.class.getName());
+    private static RegistryConnection connection1;
+    private static RegistryConnection connection2;
+    private static boolean operationCompleted;
+    public EventTest() {
+
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        connection1 = new RegistryConnection("localhost:2181");
+        connection1.setBaseKey("/strombrautests");
+        connection1.connect();
+        
+        connection2 = new RegistryConnection("localhost:2181");
+        connection2.setBaseKey("/strombrautests");
+        connection2.connect();
+        
+        logger.info("Zookeeper connected");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        connection1.close();
+        connection2.close();
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    // TODO add test methods here.
+    // The methods must be annotated with annotation @Test. For example:
+    //
+    @Test
+    public void testListener() throws Exception {
+        final RegistryKeyListener<EventType> listener = connection2.addKeyListener("events", new RegistryKeyListener<EventType>() {
+            @Override
+            public void objectAdded(EventType value) {
+                logger.info("OBJECT_ADDED event:" + value.name);
+                
+                try {
+                    for(EventType evt : getValues()){
+                        logger.info(evt.toString());
+                    }
+                } catch (RegistryException re){
+                    re.printStackTrace();
+                    fail();
+                }
+            }
+
+            @Override
+            public void objectRemoved(EventType value) {
+                logger.info("OBJECT_REMOVED event: " + value);
+            }
+
+            @Override
+            public void objectChanged(EventType value) {
+                logger.info("OBJECT_CHANGED event: " + value);
+            }
+        });
+        
+
+        operationCompleted = false;
+        connection1.execute(new CreateEventType(new EventType("MeterReading"))).thenRun(new Runnable() {
+            @Override
+            public void run() {
+                logger.info("MeterReading added");
+                EventType updated = new EventType("MeterReading");
+                updated.topicName = "TOPICS/METERREADING";
+                connection1.execute(new CreateEventType(updated)).thenRun(new Runnable() {
+                    @Override
+                    public void run() {
+                        logger.info("MeterReading modified");
+                        
+                        // List event types
+                        try {
+                            final ListEventTypes list = new ListEventTypes();
+                            connection1.executeSync(list);
+                            for(EventType evt : list.getResults()){
+                                logger.info(evt.toString());
+                            }
+                        } catch (Exception e){
+                            logger.log(Level.SEVERE, "Error listing event types:" + e.getMessage());
+                            fail();
+                        }
+                        
+                        
+                        // Wait for a second before deleting
+                        try {
+                            Thread.sleep(1000);
+                        } catch (Exception e){}
+                        connection1.execute(new RemoveEventType("MeterReading")).thenRun(new Runnable() {
+                            @Override
+                            public void run() {
+                                logger.info("MeterReading removed");
+                                operationCompleted = true;
+                            }
+                        });
+                    }
+
+                }
+                );
+            }
+        });
+
+
+        while(!operationCompleted){
+            Thread.sleep(100);
+        }
+    }
+}

--- a/src/test/java/io/streamzi/registry/tests/RegistryTest.java
+++ b/src/test/java/io/streamzi/registry/tests/RegistryTest.java
@@ -1,0 +1,73 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package io.streamzi.registry.tests;
+
+import io.streamzi.registry.RegistryConnection;
+import java.util.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * Test the registry function
+ *
+ * @author hhiden
+ */
+public class RegistryTest {
+
+    private static final Logger logger = Logger.getLogger(RegistryTest.class.getName());
+    private static RegistryConnection connection;
+
+    public RegistryTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        connection = new RegistryConnection("localhost:2181");
+        connection.setBaseKey("/strombrautests");
+        connection.connect();
+        logger.info("Zookeeper connected");
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        try {
+            connection.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    
+    @Test
+    public void registerKey() throws Exception {
+        logger.info("Registering key");
+        String data = "This is some test data";
+        connection.setStringForKey("testdata", data);
+        String returnData = connection.getStringForKey("testdata");
+        assertEquals(data, returnData);
+
+        // Try setting it again
+        data = "This is some new data";
+        connection.setStringForKey("testdata", data);
+        returnData = connection.getStringForKey("testdata");
+        assertEquals(data, returnData);
+
+    }
+    
+
+}


### PR DESCRIPTION
This is some intial work to implement a registry on top of Zookeeper that can keep track of event-types, topics, routes etc. It only stores really basic event-types at the moment, but can be extended to include other stuff. 

Listeners can be added which are then kept updated when things are added/removed/changed